### PR TITLE
fix: adjust DefaultPowerReduction for 18 decimals and force validators state update

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -5,6 +5,7 @@
 package app
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1006,6 +1007,56 @@ func NewTacChainApp(
 	return app
 }
 
+// fix for tacchain_2390-1 chain halt at height 3192450
+func (app *TacChainApp) fixValidatorsState(ctx sdk.Context) error {
+	validators, err := app.StakingKeeper.GetAllValidators(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get all validators: %s", err)
+	}
+
+	for _, validator := range validators {
+		store := ctx.KVStore(app.GetKey(stakingtypes.StoreKey))
+
+		deleted := false
+
+		iterator := storetypes.KVStorePrefixIterator(store, stakingtypes.ValidatorsByPowerIndexKey)
+		defer iterator.Close()
+
+		for ; iterator.Valid(); iterator.Next() {
+			valAddr := stakingtypes.ParseValidatorPowerRankKey(iterator.Key())
+			val := sdk.ValAddress(valAddr).String()
+
+			// get operator addr
+			var operator sdk.ValAddress = nil
+			if validator.OperatorAddress != "" {
+				addr, err := sdk.ValAddressFromBech32(validator.OperatorAddress)
+				if err != nil {
+					return fmt.Errorf("failed to parse operator address: %s", err)
+				}
+				operator = addr
+			}
+
+			if bytes.Equal(valAddr, operator) {
+				if deleted {
+					fmt.Println("Duplicate validator address is: " + val)
+				} else {
+					deleted = true
+				}
+				store.Delete(iterator.Key())
+			}
+		}
+
+		if err := app.StakingKeeper.SetValidatorByPowerIndex(ctx, validator); err != nil {
+			return fmt.Errorf("failed to set validator by power index: %s", err)
+		}
+		if _, err := app.StakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx); err != nil {
+			return fmt.Errorf("failed to apply and return validator set updates: %s", err)
+		}
+	}
+
+	return nil
+}
+
 func (app *TacChainApp) setAnteHandler(txConfig client.TxConfig, maxGasWanted uint64, wasmConfig wasmtypes.WasmConfig, txCounterStoreKey *storetypes.KVStoreKey) {
 	anteHandler, err := NewAnteHandler(HandlerOptions{
 		HandlerOptions: authante.HandlerOptions{
@@ -1062,6 +1113,12 @@ func (app *TacChainApp) PreBlocker(ctx sdk.Context, _ *abci.RequestFinalizeBlock
 
 // BeginBlocker application updates every begin block
 func (app *TacChainApp) BeginBlocker(ctx sdk.Context) (sdk.BeginBlock, error) {
+	if app.ChainID() == DefaultChainID && app.LastBlockHeight() == 3192450 {
+		// fix for tacchain_2390-1 chain halt at height 3192450
+		if err := app.fixValidatorsState(ctx); err != nil {
+			panic(fmt.Sprintf("failed to fix validators state: %s", err))
+		}
+	}
 	return app.ModuleManager.BeginBlock(ctx)
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -1113,12 +1113,13 @@ func (app *TacChainApp) PreBlocker(ctx sdk.Context, _ *abci.RequestFinalizeBlock
 
 // BeginBlocker application updates every begin block
 func (app *TacChainApp) BeginBlocker(ctx sdk.Context) (sdk.BeginBlock, error) {
-	if app.ChainID() == DefaultChainID && app.LastBlockHeight() == 3192450 {
-		// fix for tacchain_2390-1 chain halt at height 3192450
+	// fix for tacchain_2390-1 chain halt at height 3192450
+	if app.ChainID() == DefaultChainID && app.LastBlockHeight() == 3192449 {
 		if err := app.fixValidatorsState(ctx); err != nil {
 			panic(fmt.Sprintf("failed to fix validators state: %s", err))
 		}
 	}
+
 	return app.ModuleManager.BeginBlock(ctx)
 }
 

--- a/app/config.go
+++ b/app/config.go
@@ -5,6 +5,7 @@
 package app
 
 import (
+	"math/big"
 	"os"
 
 	simappparams "cosmossdk.io/simapp/params"
@@ -53,6 +54,9 @@ var (
 	Bech32PrefixConsPub = Bech32PrefixAccAddr + "valconspub"
 
 	DefaultNodeHome = os.ExpandEnv("$HOME/") + NodeDir
+
+	// PowerReduction defines the default power reduction value for staking
+	PowerReduction = sdkmath.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(BaseDenomUnit), nil))
 )
 
 func init() {
@@ -63,6 +67,7 @@ func init() {
 // RegisterDenoms registers token denoms.
 func RegisterDenoms() {
 	sdk.DefaultBondDenom = BaseDenom
+	sdk.DefaultPowerReduction = PowerReduction
 
 	config := sdk.GetConfig()
 	ethermintcmdcfg.SetBip44CoinType(config)


### PR DESCRIPTION
Tac Testnet  (tacchain_2390-1) faced a chain halt last night at height 3192450. Issue was related to a cosmos-sdk variable `DefaultPowerReduction` which was hardcoded for 6 decimal token. Our network is using 18 decimals, therefore at some point, especially we started testing staking more extensively, our validators hit voting power limit that was based on the variable mentioned previously. After applying fix for that, the network faced another which was caused by validators still having state based on old power reduction calculations. This required us to update the validators state, which is usually achieved using software upgrade proposals. In our case the chain was already halted and we didn't have a way to make one, threfore we forced the update in BeginBlocker.