### PR TITLE
chore: change token denom responsibility with power reduction

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	DisplayDenom  = "tac"
-	BaseDenom     = "utac"
+	BaseDenom     = "atac"
 	BaseDenomUnit = 18
 
 	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address.


### PR DESCRIPTION
Tac chain currently using token with decimal 18 but token denom is "utac" which may cause confusion to decimal 6. 
This pr will change token denom from "utac" to "atac" which is related to decimal 18.
