### PR TITLE
feat: add to v1.6.0 upgrade correcting blocks_per_year

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -43,6 +43,7 @@ func (app *TacChainApp) RegisterUpgradeHandlers() {
 		StakingKeeper:         app.StakingKeeper,
 		EVMKeeper:             app.EVMKeeper,
 		DistrKeeper:           &app.DistrKeeper,
+		MintKeeper:            &app.MintKeeper,
 	}
 	app.GetStoreKeys()
 	// register all upgrade handlers

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -17,6 +17,7 @@ import (
 
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
 	evmerc20keeper "github.com/cosmos/evm/x/erc20/keeper"
 	liquidstakekeeper "github.com/cosmos/evm/x/liquidstake/keeper"
 
@@ -36,6 +37,7 @@ type AppKeepers struct {
 	StakingKeeper         *stakingkeeper.Keeper
 	EVMKeeper             *evmvmkeeper.Keeper
 	DistrKeeper           *distrkeeper.Keeper
+	MintKeeper            *mintkeeper.Keeper
 }
 
 type ModuleManager interface {

--- a/app/upgrades/v1.6.0/mint_params_migration.go
+++ b/app/upgrades/v1.6.0/mint_params_migration.go
@@ -1,0 +1,58 @@
+package v160
+
+// mint_params_migration.go corrects the x/mint blocks_per_year parameter.
+//
+// blocks_per_year was originally set to 15_768_000, which assumes a 2.0s block
+// time (365 * 86400 / 2.0). The mint module mints exactly
+// annual_provisions / blocks_per_year per block, regardless of wall-clock time,
+// so with the real mainnet block time (~1.553s) the chain minted materially
+// more tokens per year than the nominal inflation rate implied
+// (actual emission ≈ nominal × 2.0 / block_time).
+//
+// TargetBlocksPerYear ≈ 365 * 86400 / 1.553, which re-aligns per-block emission
+// with the nominal inflation rate. Only blocks_per_year is touched here; the
+// inflation curve (inflation_max, inflation_min, goal_bonded,
+// inflation_rate_change) is intentionally left unchanged.
+
+import (
+	"fmt"
+
+	"github.com/TacBuild/tacchain/app/upgrades"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// TargetBlocksPerYear is the corrected x/mint blocks_per_year value for mainnet.
+const TargetBlocksPerYear uint64 = 20_300_000
+
+// migrateMintBlocksPerYear sets x/mint Params.BlocksPerYear to
+// TargetBlocksPerYear, leaving every other mint parameter untouched. It is a
+// no-op if the value is already at the target.
+func migrateMintBlocksPerYear(ctx sdk.Context, ak *upgrades.AppKeepers) error {
+	if ak.MintKeeper == nil {
+		return fmt.Errorf("mint keeper not wired into AppKeepers")
+	}
+
+	params, err := ak.MintKeeper.Params.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("get mint params: %w", err)
+	}
+
+	old := params.BlocksPerYear
+	if old == TargetBlocksPerYear {
+		ctx.Logger().Info("x/mint blocks_per_year already at target; skipping",
+			"blocks_per_year", old)
+		return nil
+	}
+
+	params.BlocksPerYear = TargetBlocksPerYear
+	if err := params.Validate(); err != nil {
+		return fmt.Errorf("validate mint params after blocks_per_year change: %w", err)
+	}
+	if err := ak.MintKeeper.Params.Set(ctx, params); err != nil {
+		return fmt.Errorf("set mint params: %w", err)
+	}
+
+	ctx.Logger().Info("Corrected x/mint blocks_per_year",
+		"old", old, "new", TargetBlocksPerYear)
+	return nil
+}

--- a/app/upgrades/v1.6.0/mint_params_migration_test.go
+++ b/app/upgrades/v1.6.0/mint_params_migration_test.go
@@ -1,0 +1,86 @@
+package v160
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/TacBuild/tacchain/app/upgrades"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/cosmos/cosmos-sdk/x/mint"
+	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
+	minttestutil "github.com/cosmos/cosmos-sdk/x/mint/testutil"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+)
+
+func newMintTestKeeper(t *testing.T) (sdk.Context, *mintkeeper.Keeper) {
+	t.Helper()
+
+	encCfg := moduletestutil.MakeTestEncodingConfig(mint.AppModuleBasic{})
+	key := storetypes.NewKVStoreKey(minttypes.StoreKey)
+	storeService := runtime.NewKVStoreService(key)
+	testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+	ctx := testCtx.Ctx
+
+	ctrl := gomock.NewController(t)
+	accountKeeper := minttestutil.NewMockAccountKeeper(ctrl)
+	bankKeeper := minttestutil.NewMockBankKeeper(ctrl)
+	stakingKeeper := minttestutil.NewMockStakingKeeper(ctrl)
+	accountKeeper.EXPECT().GetModuleAddress(minttypes.ModuleName).
+		Return(authtypes.NewModuleAddress(minttypes.ModuleName))
+
+	k := mintkeeper.NewKeeper(
+		encCfg.Codec,
+		storeService,
+		stakingKeeper,
+		accountKeeper,
+		bankKeeper,
+		authtypes.FeeCollectorName,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	return ctx, &k
+}
+
+func TestMigrateMintBlocksPerYear(t *testing.T) {
+	ctx, k := newMintTestKeeper(t)
+
+	// Seed mainnet-like params with the legacy value that assumed a 2.0s block.
+	params := minttypes.DefaultParams()
+	params.MintDenom = "utac"
+	params.BlocksPerYear = 15_768_000
+	require.NoError(t, k.Params.Set(ctx, params))
+
+	ak := &upgrades.AppKeepers{MintKeeper: k}
+	require.NoError(t, migrateMintBlocksPerYear(ctx, ak))
+
+	got, err := k.Params.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(20_300_000), got.BlocksPerYear)
+	require.Equal(t, TargetBlocksPerYear, got.BlocksPerYear)
+
+	// Every other parameter must be left untouched (inflation curve preserved).
+	require.Equal(t, params.MintDenom, got.MintDenom)
+	require.True(t, params.InflationMax.Equal(got.InflationMax))
+	require.True(t, params.InflationMin.Equal(got.InflationMin))
+	require.True(t, params.InflationRateChange.Equal(got.InflationRateChange))
+	require.True(t, params.GoalBonded.Equal(got.GoalBonded))
+
+	// Idempotent: a second run is a no-op and stays at target.
+	require.NoError(t, migrateMintBlocksPerYear(ctx, ak))
+	got2, err := k.Params.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, TargetBlocksPerYear, got2.BlocksPerYear)
+}
+
+func TestMigrateMintBlocksPerYearNilKeeper(t *testing.T) {
+	err := migrateMintBlocksPerYear(sdk.Context{}, &upgrades.AppKeepers{})
+	require.Error(t, err)
+}

--- a/app/upgrades/v1.6.0/upgrades.go
+++ b/app/upgrades/v1.6.0/upgrades.go
@@ -165,6 +165,17 @@ func CreateUpgradeHandler(
 			return nil, fmt.Errorf("staking LSM accounting rebuild failed: %w", err)
 		}
 
+		// ── Step 5: x/mint blocks_per_year correction ──────────────────────
+		//
+		// blocks_per_year was set assuming a 2.0s block time, but mainnet runs
+		// at ~1.553s, so the chain over-mints relative to the nominal inflation
+		// rate. Re-align per-block emission with the inflation rate. Runs after
+		// RunMigrations so the mint module migration cannot overwrite it.
+		logger.Info("Correcting x/mint blocks_per_year")
+		if err := migrateMintBlocksPerYear(sdkCtx, ak); err != nil {
+			return nil, fmt.Errorf("mint blocks_per_year correction failed: %w", err)
+		}
+
 		logger.Info("v1.6.0 upgrade complete")
 		return vm, nil
 	}


### PR DESCRIPTION
correcting x/mint blocks_per_year to ~1.553s blocktime