### PR TITLE
fix(app): wire historical EVM decode resolvers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -39,6 +39,7 @@ import (
 	"github.com/spf13/cast"
 
 	appconfig "github.com/TacBuild/tacchain/app/config"
+	v160 "github.com/TacBuild/tacchain/app/upgrades/v1.6.0"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
@@ -584,6 +585,23 @@ func NewTacChainApp(
 		Decimals:      evmvmtypes.EighteenDecimals.Uint32(),
 	})
 
+	// Enable historical decoding of pre-v1.6.0 EVM state so that eth_call and
+	// other read-only queries below the migration height keep working:
+	//   - x/vm Params changed proto field numbers (decode would panic);
+	//   - x/erc20 precompile lists moved store layout (precompiles would appear
+	//     unregistered, so calls execute the decoy ERC20 bytecode instead).
+	// The migration height is governance-decided (and differs across networks),
+	// so it is resolved lazily from the applied x/upgrade done-height; before the
+	// upgrade it resolves to 0 (no-op).
+	resolveV160Height := func(ctx sdk.Context) int64 {
+		height, err := app.UpgradeKeeper.GetDoneHeight(ctx, v160.UpgradeName)
+		if err != nil {
+			return 0
+		}
+		return height
+	}
+	app.EVMKeeper.SetLegacyParamsHeightResolver(resolveV160Height)
+
 	app.Erc20Keeper = evmerc20keeper.NewKeeper(
 		keys[evmerc20types.StoreKey],
 		encodingConfig.Codec,
@@ -594,6 +612,7 @@ func NewTacChainApp(
 		app.StakingKeeper,
 		&app.TransferKeeper,
 	)
+	app.Erc20Keeper.SetLegacyPrecompilesHeightResolver(resolveV160Height)
 
 	// instantiate IBC transfer keeper AFTER the ERC-20 keeper to use it in the instantiation
 	app.TransferKeeper = ibctransferkeeper.NewKeeper(

--- a/go.mod
+++ b/go.mod
@@ -291,7 +291,7 @@ replace (
 	// fix liquid stake espilon. See: https://github.com/TacBuild/evm/pull/10
 	// fix ed25519 precompile gas cost. See: https://github.com/TacBuild/evm/pull/11
 	// bump to v0.6.0
-	github.com/cosmos/evm => github.com/TacBuild/evm v0.6.0-tac.8
+	github.com/cosmos/evm => github.com/TacBuild/evm v0.6.0-tac.9
 
 	// replace with our fork using geth v1.16.2
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.16.2-cosmos-1

--- a/go.sum
+++ b/go.sum
@@ -685,8 +685,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/TacBuild/cosmos-sdk v0.53.6-tac.2 h1:XsSuogKqfso4o2geMMUuKZggo0aiZzfw/P5SAMAtY9Q=
 github.com/TacBuild/cosmos-sdk v0.53.6-tac.2/go.mod h1:N6YuprhAabInbT3YGumGDKONbvPX5dNro7RjHvkQoKE=
-github.com/TacBuild/evm v0.6.0-tac.8 h1:SHvB6L27rY+gB4m0UKgnRMKf9+r9DrYabu3zMqL/djk=
-github.com/TacBuild/evm v0.6.0-tac.8/go.mod h1:1ftehWYVTdW6XlSIAzRxFrNVDGnLxi17o8b/LTiZhEE=
+github.com/TacBuild/evm v0.6.0-tac.9 h1:IlGFOWEEWTpuiAOyxqPLP8K6Mq1PejjntH2oOtPIFPk=
+github.com/TacBuild/evm v0.6.0-tac.9/go.mod h1:1ftehWYVTdW6XlSIAzRxFrNVDGnLxi17o8b/LTiZhEE=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=


### PR DESCRIPTION
Wire the x/vm and x/erc20 legacy-decode resolvers from the applied x/upgrade done-height so historical eth_call below the v1.6.0 migration height keeps working (pairs with evm branch
fix/historical-eth-call-legacy-decode):
- EVMKeeper.SetLegacyParamsHeightResolver
- Erc20Keeper.SetLegacyPrecompilesHeightResolver