### PR TITLE
feat: Upgrade v1.6.1

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -14,6 +14,7 @@ import (
 	v104 "github.com/TacBuild/tacchain/app/upgrades/v1.0.4"
 	v160 "github.com/TacBuild/tacchain/app/upgrades/v1.6.0"
 	v160spbhotfix "github.com/TacBuild/tacchain/app/upgrades/v1.6.0-spb-hotfix"
+	v161 "github.com/TacBuild/tacchain/app/upgrades/v1.6.1"
 )
 
 // Upgrades list of chain upgrades
@@ -26,6 +27,7 @@ var Upgrades = []upgrades.Upgrade{
 	v104.Upgrade, // ed25519 precompile
 	v160.Upgrade, // upgrade to cosmos/evm v0.6.0
 	v160spbhotfix.Upgrade,
+	v161.Upgrade, // vesting schedule shift (+6mo) & vesting account migration
 }
 
 // RegisterUpgradeHandlers registers the chain upgrade handlers

--- a/app/upgrades/v1.6.1/upgrades.go
+++ b/app/upgrades/v1.6.1/upgrades.go
@@ -1,0 +1,45 @@
+package v161
+
+import (
+	"context"
+	"fmt"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+
+	"github.com/TacBuild/tacchain/app/upgrades"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+const UpgradeName = "v1.6.1"
+
+// Upgrade is a no-op state upgrade: it ships binary-level fixes only and carries
+// no state migration. It exists so the network can coordinate a version bump; the
+// handler just runs standard module migrations and returns.
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        storetypes.StoreUpgrades{},
+}
+
+func CreateUpgradeHandler(
+	mm upgrades.ModuleManager,
+	configurator module.Configurator,
+	_ *upgrades.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		logger := sdkCtx.Logger()
+
+		logger.Info("Starting v1.6.1 upgrade (binary fixes only, no state migration)")
+
+		vm, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return nil, fmt.Errorf("RunMigrations failed: %w", err)
+		}
+
+		logger.Info("v1.6.1 upgrade complete")
+		return vm, nil
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -283,7 +283,8 @@ replace (
 
 	// replace to cosmos-sdk fork for liquid stake support. See: https://github.com/TacBuild/cosmos-sdk/pull/2
 	// bump to v0.53.6 with all fork specific changes.
-	github.com/cosmos/cosmos-sdk => github.com/TacBuild/cosmos-sdk v0.53.6-tac.2
+	// tac.3: emit locked_amount on coin_spent for vesting-locked delegations (paired evm tac.10).
+	github.com/cosmos/cosmos-sdk => github.com/TacBuild/cosmos-sdk v0.53.6-tac.3
 
 	// replace to cosmos/evm fork
 	// added liquid stake support. See: https://github.com/TacBuild/evm/pull/9
@@ -291,7 +292,8 @@ replace (
 	// fix liquid stake espilon. See: https://github.com/TacBuild/evm/pull/10
 	// fix ed25519 precompile gas cost. See: https://github.com/TacBuild/evm/pull/11
 	// bump to v0.6.0
-	github.com/cosmos/evm => github.com/TacBuild/evm v0.6.0-tac.9
+	// tac.10: allow delegating vesting-locked tokens via staking precompile (amount-locked; needs cosmos-sdk tac.3).
+	github.com/cosmos/evm => github.com/TacBuild/evm v0.6.0-tac.10
 
 	// replace with our fork using geth v1.16.2
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.16.2-cosmos-1

--- a/go.sum
+++ b/go.sum
@@ -683,10 +683,10 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/TacBuild/cosmos-sdk v0.53.6-tac.2 h1:XsSuogKqfso4o2geMMUuKZggo0aiZzfw/P5SAMAtY9Q=
-github.com/TacBuild/cosmos-sdk v0.53.6-tac.2/go.mod h1:N6YuprhAabInbT3YGumGDKONbvPX5dNro7RjHvkQoKE=
-github.com/TacBuild/evm v0.6.0-tac.9 h1:IlGFOWEEWTpuiAOyxqPLP8K6Mq1PejjntH2oOtPIFPk=
-github.com/TacBuild/evm v0.6.0-tac.9/go.mod h1:1ftehWYVTdW6XlSIAzRxFrNVDGnLxi17o8b/LTiZhEE=
+github.com/TacBuild/cosmos-sdk v0.53.6-tac.3 h1:tKkYpmiVGrCFy3V11fCy/AP+JOu3duawBzQVOIQgl5s=
+github.com/TacBuild/cosmos-sdk v0.53.6-tac.3/go.mod h1:N6YuprhAabInbT3YGumGDKONbvPX5dNro7RjHvkQoKE=
+github.com/TacBuild/evm v0.6.0-tac.10 h1:XJuFhP+eZK48NgNY2ywnHTdi0tGNJMrjSHMlxGzPezc=
+github.com/TacBuild/evm v0.6.0-tac.10/go.mod h1:9DaIfOYirXAQplL677tYEmy0crZWLI4glre84+qi5FQ=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=


### PR DESCRIPTION
## v1.6.1 — upgrade handler + vesting-locked delegation fix

Coordinated version bump, binary fixes only (no state migration).

- Empty v1.6.1 handler (`RunMigrations` + return) for the version bump.
- Bump forks: `cosmos-sdk v0.53.6-tac.3` + `evm v0.6.0-tac.10`.

**Fix:** delegating vesting-locked tokens via the staking precompile (0x800) used to burn (within spendable) or overflow-panic / get stuck (beyond spendable), since EVM tracks only spendable balance. Bank now tags the locked portion on `coin_spent` and the handler subtracts `amount − locked` → delegation works, supply conserved.

Tested: fork tests + localnet e2e (beyond 50k + within delegations pass, holdings conserved, no burn/panic).